### PR TITLE
Temporary workaround to restore working loading overlay

### DIFF
--- a/client/src/pages/LoadFile.vue
+++ b/client/src/pages/LoadFile.vue
@@ -116,7 +116,7 @@ export default {
 };
 </script>
 
-<style scoped>
+<style>
 #textinput-textarea {
   width: 60%;
   height: 500px;
@@ -143,7 +143,9 @@ export default {
   opacity: 0;
 }
 
-circle {
-  fill: transparent !important;
+.vld-overlay circle {
+  fill: unset;
+  stroke: unset;
+  stroke-width: unset;
 }
 </style>


### PR DESCRIPTION
Styles in LoadFile cannot be nested as they stops working correctly. I changed the way I address styles for circle in overlay and it should not influence other files especially these connected with graph. However I still recommend change the way circles in graph are addressed because every new style for circle from Graph needs to be unset in LoadFile for overlay to work properly.