### PR TITLE
Uploading text for processing on server

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,6 +9,7 @@
     "lint-fix": "eslint --ext .js,.vue src --fix"
   },
   "dependencies": {
+    "axios": "^0.19.2",
     "core-js": "^3.6.4",
     "d3": "^5.16.0",
     "file-saver": "^2.0.2",

--- a/client/src/components/Layout/Menu.vue
+++ b/client/src/components/Layout/Menu.vue
@@ -1,7 +1,7 @@
 <template>
   <v-navigation-drawer v-model="drawer" app>
     <v-list dense>
-      <v-list-item link to="/visualise-data">
+      <v-list-item link :to="`/visualise-data/0`">
         <v-list-item-content>
           <v-list-item-title class="text-center"
             >Visualise Data</v-list-item-title

--- a/client/src/components/VisualiseData.vue
+++ b/client/src/components/VisualiseData.vue
@@ -149,6 +149,7 @@ export default {
   components: {
     ForceGraph
   },
+  props: ["id"],
   data() {
     return {
       sliderNodes: 100,
@@ -183,6 +184,7 @@ export default {
   },
   mounted() {
     this.changeData();
+    console.log(this.$props.id); // added just to show that passed id can be used
   },
   methods: {
     nodes() {

--- a/client/src/components/VisualiseData.vue
+++ b/client/src/components/VisualiseData.vue
@@ -1,5 +1,10 @@
 <template>
   <v-row justify="center" align="center">
+    <loading
+      :active.sync="isLoading"
+      :can-cancel="false"
+      :is-full-page="true"
+    ></loading>
     <v-row>
       <ForceGraph
         :data="getDataFilteredBySensitivity"
@@ -144,11 +149,14 @@ import { saveAs } from "file-saver";
 import { saveSvgAsPng } from "save-svg-as-png";
 import removedNodeTag from "../plugins/const";
 import axios from "axios";
+import Loading from "vue-loading-overlay";
+import "vue-loading-overlay/dist/vue-loading.css";
 
 export default {
   name: "VisualizeData",
   components: {
-    ForceGraph
+    ForceGraph,
+    Loading
   },
   props: ["id"],
   data() {
@@ -168,7 +176,8 @@ export default {
       inputUrl:
         "https://gist.githubusercontent.com/DawidPiechota/2cee2d1c35f68b619164f7c2797be57e/raw/0ecace4aed4f770b3d80f1d57095715f1af66885/data3NoTypes.json",
       fileToUpload: null,
-      isFileToUpload: null
+      isFileToUpload: null,
+      isLoading: true
     };
   },
   computed: {
@@ -280,6 +289,7 @@ export default {
         this.data = JSON.parse(JSON.stringify(data));
         this.items = this.nodes();
         this.setMaxSensitivityValues();
+        this.isLoading = false;
       });
     },
     loadJsonFromDb() {
@@ -296,6 +306,7 @@ export default {
             this.data = response.data.graph.nodesData;
             this.items = this.nodes();
             this.setMaxSensitivityValues();
+            this.isLoading = false;
           } else {
             setTimeout(this.loadJsonFromDb, 2000);
           }

--- a/client/src/pages/LoadFile.vue
+++ b/client/src/pages/LoadFile.vue
@@ -14,7 +14,22 @@
               <h1>Load text for analysis</h1>
             </v-col>
           </v-row>
-          <v-row>
+          <v-row v-show="isErrorResponse">
+            <v-col cols="12" align="center">
+              <p style="color:red;">
+                There was an error while sending your data. Try again.
+              </p>
+            </v-col>
+          </v-row>
+          <v-row v-show="isSuccessfulResponse">
+            <v-col cols="12" align="center">
+              <p>
+                Your data has been successfully submitted. It will be available
+                when processed here.
+              </p>
+            </v-col>
+          </v-row>
+          <v-row v-show="isInputBoxShown">
             <v-col cols="2"></v-col>
             <v-col cols="8" align="center">
               <v-textarea
@@ -27,7 +42,7 @@
             </v-col>
             <v-col cols="2"></v-col>
           </v-row>
-          <v-row>
+          <v-row v-show="isInputBoxShown">
             <v-col cols="12" align="center">
               <p style="margin-bottom: 10px;">
                 or upload a file below. Supported files: txt, pdf.
@@ -42,9 +57,11 @@
               </label>
             </v-col>
           </v-row>
-          <v-row>
+          <v-row v-show="isInputBoxShown">
             <v-col cols="12" align="center">
-              <v-btn color="success">Send for analysis</v-btn>
+              <v-btn color="success" v-on:click="submitData"
+                >Send for analysis</v-btn
+              >
             </v-col>
           </v-row>
         </v-col>
@@ -57,9 +74,18 @@
 import Loading from "vue-loading-overlay";
 import "vue-loading-overlay/dist/vue-loading.css";
 import pdfjsLib from "pdfjs-dist";
+import axios from "axios";
 
 export default {
-  data: () => ({ text: "", isLoading: false, fullPage: true }),
+  data: () => ({
+    text: "",
+    isLoading: false,
+    fullPage: true,
+    isInputBoxShown: true,
+    isErrorResponse: false,
+    isSuccessfulResponse: false,
+    submissionId: -1
+  }),
   methods: {
     loadTextFromFile(ev) {
       this.isLoading = true;
@@ -108,6 +134,34 @@ export default {
           .join(" ");
       });
       return (await Promise.all(pageTexts)).join("\n");
+    },
+    submitData(ev) {
+      this.isLoading = true;
+      this.isInputBoxShown = false;
+      this.isErrorResponse = false;
+      return axios
+        .post(
+          "http://127.0.0.1:5000/methodOne",
+          { text: this.text },
+          {
+            headers: {
+              "Content-type": "application/json"
+            }
+          }
+        )
+        .then(response => {
+          this.submissionId = response.data.id;
+          console.log("response: " + JSON.stringify(response.data, null, 2));
+          console.log(this.submissionId);
+          this.isSuccessfulResponse = true;
+          this.isLoading = false;
+        })
+        .catch(error => {
+          console.log("error: " + error);
+          this.isInputBoxShown = true;
+          this.isErrorResponse = true;
+          this.isLoading = false;
+        });
     }
   },
   components: {

--- a/client/src/pages/LoadFile.vue
+++ b/client/src/pages/LoadFile.vue
@@ -148,7 +148,7 @@ export default {
       return axios
         .post(
           "http://127.0.0.1:5000/methodOne",
-          { text: this.text },
+          { name: "test", text: this.text }, // TODO: add field for text name input
           {
             headers: {
               "Content-type": "application/json"
@@ -156,7 +156,7 @@ export default {
           }
         )
         .then(response => {
-          this.submissionId = response.data.id;
+          this.submissionId = response.data;
           this.isSuccessfulResponse = true;
           this.isLoading = false;
         })

--- a/client/src/pages/LoadFile.vue
+++ b/client/src/pages/LoadFile.vue
@@ -4,7 +4,7 @@
       :active.sync="isLoading"
       :can-cancel="false"
       :on-cancel="onCancel"
-      :is-full-page="fullPage"
+      :is-full-page="true"
     ></loading>
     <v-row justify="center" align="center">
       <v-row>
@@ -86,7 +86,6 @@ export default {
   data: () => ({
     text: "",
     isLoading: false,
-    fullPage: true,
     isInputBoxShown: true,
     isErrorResponse: false,
     isSuccessfulResponse: false,

--- a/client/src/pages/LoadFile.vue
+++ b/client/src/pages/LoadFile.vue
@@ -24,8 +24,14 @@
           <v-row v-show="isSuccessfulResponse">
             <v-col cols="12" align="center">
               <p>
-                Your data has been successfully submitted. It will be available
-                when processed here.
+                Your data has been successfully submitted.
+              </p>
+              <p>Your submission ID is {{ this.submissionId }}.</p>
+              <p>
+                It will be available when processed
+                <router-link :to="`/visualise-data/${this.submissionId}`"
+                  >here</router-link
+                >.
               </p>
             </v-col>
           </v-row>
@@ -151,8 +157,6 @@ export default {
         )
         .then(response => {
           this.submissionId = response.data.id;
-          console.log("response: " + JSON.stringify(response.data, null, 2));
-          console.log(this.submissionId);
           this.isSuccessfulResponse = true;
           this.isLoading = false;
         })

--- a/client/src/plugins/router.js
+++ b/client/src/plugins/router.js
@@ -23,9 +23,10 @@ export default new Router({
     },
 
     {
-      path: "/visualise-data",
+      path: "/visualise-data/:id",
       name: "VisualiseData",
-      component: VisualiseData
+      component: VisualiseData,
+      props: true
     },
     {
       path: "/load-file",

--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -1,3 +1,9 @@
 module.exports = {
+  configureWebpack: {
+    devServer: {
+      headers: { "Access-Control-Allow-Origin": "*" }
+      // should be taken care of when deployed publicly
+    }
+  },
   transpileDependencies: ["vuetify"]
 };

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1653,6 +1653,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
 
+axios@^0.19.2:
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
+  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
+  dependencies:
+    follow-redirects "1.5.10"
+
 babel-eslint@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
@@ -3061,6 +3068,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.0.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -4193,6 +4207,13 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
+  dependencies:
+    debug "=3.1.0"
 
 follow-redirects@^1.0.0:
   version "1.11.0"

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -219,3 +219,4 @@ pip-selfcheck.json
 # End of https://www.gitignore.io/api/python,virtualenv
 
 *.db
+demofile2.txt

--- a/server/app/controllers/algorithm.py
+++ b/server/app/controllers/algorithm.py
@@ -24,8 +24,7 @@ class Algorithm(MethodView):
             return str(500)
 
     def get(self):
-        dataFromJson = request.get_json()
-        gID = dataFromJson['id']
+        gID = request.args.get('id')
         g = Graph.query.filter_by(id=gID).first()
 
         if g.ready:

--- a/server/app/services/app.py
+++ b/server/app/services/app.py
@@ -1,3 +1,6 @@
 from flask import Flask
+from flask_cors import CORS
 
 app = Flask(__name__)
+CORS(app)
+# should be taken care of when deployed publicly

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,3 +3,4 @@ Flask-SQLAlchemy
 click
 flake8
 requests
+flask-cors


### PR DESCRIPTION
Hmmmm, okay, so I guess this feature is at least partially done. 

#### What do I understand by that?

* You can send text to the endpoint on the server side.
* You can read the response form the server.
* You can pass returned id to the visualize data page.

#### What do I need to continue working on that?
* Well, I need all the hotfixes to be merged, mostly `fix-loading-overlay`, as I base on this changes but others will be helpful as well.
* I need the server side to be splitted into two endpoints, one for sending text for processing, which returns only ID, and the second one which returns status of the processing and result when available.