### PR TITLE
Fix pdf loading

### DIFF
--- a/client/src/pages/LoadFile.vue
+++ b/client/src/pages/LoadFile.vue
@@ -105,9 +105,9 @@ export default {
       const pageTexts = Array.from({ length: doc.numPages }, async (v, i) => {
         return (await (await doc.getPage(i + 1)).getTextContent()).items
           .map(token => token.str)
-          .join("");
+          .join(" ");
       });
-      return (await Promise.all(pageTexts)).join("");
+      return (await Promise.all(pageTexts)).join("\n");
     }
   },
   components: {


### PR DESCRIPTION
Fix pdf file content loading that loaded without spaces. Sometimes depending on pdf it may result in multi spaces but I believe Nor can work with multiple spaces while it cant work without any.